### PR TITLE
Fix an issue with startup on Ubuntu OSes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,5 +112,6 @@ clean: stop rm ## Remove all images and containers built by the project
 
 warn: ##
 ifndef QUIET
-	sh scripts/images.sh
+	chmod +x scripts/*
+	scripts/images.sh
 endif


### PR DESCRIPTION
The sh binary will sometimes reference bash depending on the os, but not
always. When specifically referenced, it can cause compatibilities with
the script.

Remove the specific sh invocation.

close #3 